### PR TITLE
fix: create downloader for each slug

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -15,7 +15,6 @@ export class DevDocsAdapter implements vscode.WebviewPanelSerializer {
 
     private _manifests: Map<DocSlug, DocMeta>;
     private _webviews: Map<DocSlug, vscode.WebviewPanel>;
-    private _downloader: Downloader;
 
     constructor(storePath: string, extensionPath: vscode.Uri) {
         this._storePath = storePath;
@@ -23,7 +22,6 @@ export class DevDocsAdapter implements vscode.WebviewPanelSerializer {
         this._items = [];
         this._webviews = new Map;
         this._manifests = new Map;
-        this._downloader = new Downloader(storePath);
     }
 
     async items(): Promise<DocItem[]> {
@@ -36,7 +34,7 @@ export class DevDocsAdapter implements vscode.WebviewPanelSerializer {
         this._items = [];
         this._manifests = new Map;
 
-        await this._downloader.download(slugs, force);
+        await Downloader.download(this._storePath, slugs, force);
 
         for (const slug of slugs) {
             // Manifest is already loaded

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -367,10 +367,10 @@ export class Downloader {
         await this._writeFile('items.json', JSON.stringify(items));
     }
 
-    async download(slugs: DocSlug[], force = false): Promise<void> {
+    static async download(storePath: string, slugs: DocSlug[], force = false): Promise<void> {
         if (!force) {
             // Docset already on disk
-            slugs = slugs.filter(slug => !fs.existsSync(path.join(this._storePath, slug)));
+            slugs = slugs.filter(slug => !fs.existsSync(path.join(storePath, slug)));
         }
 
         await Promise.all(slugs.map(doc => window.withProgress(
@@ -379,7 +379,7 @@ export class Downloader {
                 location: ProgressLocation.Notification,
             },
             progress => {
-                const downloader = new Downloader(this._storePath);
+                const downloader = new Downloader(storePath);
                 downloader._reporter = (message, increment) => progress.report({ message, increment });
                 return downloader._download(doc);
             },

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -379,8 +379,9 @@ export class Downloader {
                 location: ProgressLocation.Notification,
             },
             progress => {
-                this._reporter = (message, increment) => progress.report({ message, increment });
-                return this._download(doc);
+                const downloader = new Downloader(this._storePath);
+                downloader._reporter = (message, increment) => progress.report({ message, increment });
+                return downloader._download(doc);
             },
         )));
     }


### PR DESCRIPTION
The current downloader run in parallel but uses the same downloader for each slug, this causes important variables like `_docsetPath` to get set to whichever promise ran last. To fix this, I create a new downloader for each slug so that each has it's `_docsetPath` variable set correctly.